### PR TITLE
Improve MVB compatibility (fixes #1)

### DIFF
--- a/src/helpdec1.c
+++ b/src/helpdec1.c
@@ -665,7 +665,7 @@ BOOL SearchFile(FILE* HelpFile, const char* FileName, long* FileLength)
 	BTREEHEADER BtreeHdr;
 	BTREENODEHEADER CurrNode;
 	long offset;
-	char TempFile[19];
+	char TempFile[128];
 	int i, n;
 
 	fseek(HelpFile, 0L, SEEK_SET);
@@ -815,7 +815,7 @@ void ListBaggage(FILE* HelpFile, FILE* hpj, BOOL before31) /* writes out [BAGGAG
 {
 	BOOL headerwritten;
 	char* leader;
-	char FileName[20];
+	char FileName[128];
 	long FileLength;
 	BUFFER buf;
 	int i, n;

--- a/src/helpdeco.c
+++ b/src/helpdeco.c
@@ -5761,7 +5761,7 @@ int main(int argc, char* argv[])
 	{
 		_splitpath(filename, drive, dir, name, ext);
 		if (ext[0] == '\0') strcpy(ext, ".hlp");
-		mvp = ext[1] == 'M';
+		mvp = (ext[1] == 'M') || (ext[1] == 'm');
 		_makepath(HelpFileName, drive, dir, name, ext);
 		f = fopen(HelpFileName, "rb");
 		if (f)

--- a/src/helpdeco.c
+++ b/src/helpdeco.c
@@ -5761,7 +5761,7 @@ int main(int argc, char* argv[])
 	{
 		_splitpath(filename, drive, dir, name, ext);
 		if (ext[0] == '\0') strcpy(ext, ".hlp");
-		mvp = (ext[1] == 'M') || (ext[1] == 'm');
+		mvp = toupper(ext[1]) == 'M';
 		_makepath(HelpFileName, drive, dir, name, ext);
 		f = fopen(HelpFileName, "rb");
 		if (f)

--- a/src/helpdeco.c
+++ b/src/helpdeco.c
@@ -1383,7 +1383,7 @@ void ExportBitmaps(FILE* HelpFile) /* export all bitmaps */
 	BUFFER buf;
 	MFILE* mf;
 	char* leader;
-	char FileName[20];
+	char FileName[128];
 	long FileLength;
 	int i, num, n, type;
 	long savepos;


### PR DESCRIPTION
The PR fixes the issue "String length exceeds decompiler limit" when decoding certain MVB files by increasing buffer sizes and fixes the handling of files with `.mvb` extension instead of `.MVB`.